### PR TITLE
Add FastAPI provisioning API

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Open **https\://\<user>.sshclaude.com** in Safari → SSO prompt → MFA / Face�
 | Component            | Language      | Responsibility                                    |
 | -------------------- | ------------- | ------------------------------------------------- |
 | **sshclaude‑cli**    | Python        | Local installer, daemon bootstrap, local UX.      |
-| **Provisioning API** | Node + tRPC   | Orbit on sshclaude.com; calls Cloudflare REST.    |
+| **Provisioning API** | Python + FastAPI | Orbit on sshclaude.com; calls Cloudflare REST.    |
 | **State store**      | Postgres      | Maps user→sub‑domain→tunnel ID.                   |
 | **Web Console**      | React/Next.js | Shows login history, rotate keys, delete service. |
 
@@ -115,6 +115,7 @@ sshclaude uninstall      # Remove tunnel + launchd service + DNS
 1. `git clone` & `make dev` (uses Poetry + pre‑commit).
 2. `.env.example` → `.env` and add Cloudflare API token for staging zone.
 3. Run local tunnel e2e with `make e2e` (uses ngrok for callback stubs).
+4. Launch the provisioning API with `sshclaude-api`.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,12 @@ rich = "^13.0"
 pyyaml = "^6.0"
 requests = "^2.32"
 tqdm = "^4.66"
+fastapi = "^0.110"
+uvicorn = "^0.27"
 
 [tool.poetry.scripts]
 sshclaude = "sshclaude.cli:cli"
+sshclaude-api = "sshclaude.api:main"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/src/sshclaude/api.py
+++ b/src/sshclaude/api.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from . import cloudflare
+
+PROVISIONED: dict[str, dict[str, str]] = {}
+
+
+class ProvisionRequest(BaseModel):
+    email: str
+    subdomain: str
+
+
+class ProvisionResponse(BaseModel):
+    tunnel_id: str
+    dns_record_id: str
+    access_app_id: str
+
+
+app = FastAPI(title="sshclaude Provisioning API")
+
+
+@app.post("/provision", response_model=ProvisionResponse)
+def provision(req: ProvisionRequest) -> ProvisionResponse:
+    try:
+        tunnel = cloudflare.create_tunnel(req.subdomain)
+        dns = cloudflare.create_dns_record(req.subdomain, tunnel["result"]["id"])
+        access = cloudflare.create_access_app(req.email, req.subdomain)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e)) from e
+
+    data = {
+        "tunnel_id": tunnel["result"]["id"],
+        "dns_record_id": dns["result"]["id"],
+        "access_app_id": access["result"]["id"],
+    }
+    PROVISIONED[req.subdomain] = data
+    return ProvisionResponse(**data)
+
+
+@app.delete("/provision/{subdomain}")
+def delete_provision(subdomain: str) -> dict[str, str]:
+    try:
+        info = PROVISIONED.pop(subdomain)
+        cloudflare.delete_access_app(info["access_app_id"])
+        cloudflare.delete_dns_record(info["dns_record_id"])
+        cloudflare.delete_tunnel(info["tunnel_id"])
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e)) from e
+    return {"status": "deleted"}
+
+
+def main() -> None:
+    import uvicorn
+
+    uvicorn.run("sshclaude.api:app", host="0.0.0.0", port=8000)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/sshclaude/cloudflare.py
+++ b/src/sshclaude/cloudflare.py
@@ -29,5 +29,80 @@ def create_tunnel(name: str) -> dict[str, Any]:
 
 
 def delete_tunnel(tunnel_id: str) -> None:
-    resp = requests.delete(f"{API_BASE}/tunnels/{tunnel_id}", headers=_headers(), timeout=30)
+    resp = requests.delete(
+        f"{API_BASE}/tunnels/{tunnel_id}", headers=_headers(), timeout=30
+    )
+    resp.raise_for_status()
+
+
+def create_dns_record(subdomain: str, tunnel_id: str) -> dict[str, Any]:
+    zone_id = os.getenv("CLOUDFLARE_ZONE_ID")
+    if not zone_id:
+        raise RuntimeError("CLOUDFLARE_ZONE_ID not set")
+    resp = requests.post(
+        f"{API_BASE}/zones/{zone_id}/dns_records",
+        json={
+            "type": "CNAME",
+            "name": subdomain,
+            "content": f"{tunnel_id}.cfargotunnel.com",
+        },
+        headers=_headers(),
+        timeout=30,
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def delete_dns_record(record_id: str) -> None:
+    zone_id = os.getenv("CLOUDFLARE_ZONE_ID")
+    if not zone_id:
+        raise RuntimeError("CLOUDFLARE_ZONE_ID not set")
+    resp = requests.delete(
+        f"{API_BASE}/zones/{zone_id}/dns_records/{record_id}",
+        headers=_headers(),
+        timeout=30,
+    )
+    resp.raise_for_status()
+
+
+def create_access_app(email: str, subdomain: str) -> dict[str, Any]:
+    account_id = os.getenv("CLOUDFLARE_ACCOUNT_ID")
+    if not account_id:
+        raise RuntimeError("CLOUDFLARE_ACCOUNT_ID not set")
+    resp = requests.post(
+        f"{API_BASE}/accounts/{account_id}/access/apps",
+        json={
+            "name": subdomain,
+            "domain": f"{subdomain}",
+            "session_duration": "15m",
+            "type": "ssh",
+        },
+        headers=_headers(),
+        timeout=30,
+    )
+    resp.raise_for_status()
+    app = resp.json()
+    policy = requests.post(
+        f"{API_BASE}/accounts/{account_id}/access/apps/{app['result']['id']}/policies",
+        json={
+            "name": "default",
+            "decision": "allow",
+            "include": [{"emails": [email]}],
+        },
+        headers=_headers(),
+        timeout=30,
+    )
+    policy.raise_for_status()
+    return app
+
+
+def delete_access_app(app_id: str) -> None:
+    account_id = os.getenv("CLOUDFLARE_ACCOUNT_ID")
+    if not account_id:
+        raise RuntimeError("CLOUDFLARE_ACCOUNT_ID not set")
+    resp = requests.delete(
+        f"{API_BASE}/accounts/{account_id}/access/apps/{app_id}",
+        headers=_headers(),
+        timeout=30,
+    )
     resp.raise_for_status()


### PR DESCRIPTION
## Summary
- implement FastAPI server providing provisioning endpoints
- extend Cloudflare helper with DNS and Access helpers
- expose new `sshclaude-api` command in package
- document API in README

## Testing
- `black src/sshclaude/api.py src/sshclaude/cloudflare.py`
- `isort src/sshclaude/api.py src/sshclaude/cloudflare.py`
- ❌ `pre-commit run --files pyproject.toml src/sshclaude/api.py src/sshclaude/cloudflare.py README.md` *(failed: pre-commit not installed)*


------
https://chatgpt.com/codex/tasks/task_e_686a067b4704832d9b66a1582efae13d