### PR TITLE
Add setup_env script

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ sshclaude uninstall      # Remove tunnel + launchd service + DNS
 
 ## 🛠 Development
 
-1. `git clone` & `make dev` (uses Poetry + pre‑commit).
+1. `git clone` then run `./setup_env.sh` (or `make dev`) to install dependencies and pre‑commit hooks.
 2. `.env.example` → `.env` and add Cloudflare API token for staging zone.
 3. Run local tunnel e2e with `make e2e` (uses ngrok for callback stubs).
 4. Launch the provisioning API with `sshclaude-api`.

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python3 -m pip install --upgrade pip
+python3 -m pip install poetry pre-commit
+
+poetry install --no-interaction
+pre-commit install
+
+echo "Copy .env.example to .env and set CLOUDFLARE_TOKEN before running the app."


### PR DESCRIPTION
## Summary
- add `setup_env.sh` script for installing dependencies
- update README Development section

## Testing
- `pre-commit`

------
https://chatgpt.com/codex/tasks/task_e_686a090cae18832db9c0acf6dd89453e