### PR TITLE
Implement provisioning API calls

### DIFF
--- a/src/sshclaude/cli.py
+++ b/src/sshclaude/cli.py
@@ -3,10 +3,12 @@ import subprocess
 from pathlib import Path
 
 import click
+import requests
 from rich.console import Console
 from rich.progress import Progress
 
 CONFIG_FILE = Path.home() / ".sshclaude" / "config.yaml"
+API_URL = os.getenv("SSHCLAUDE_API", "http://localhost:8000")
 console = Console()
 
 
@@ -57,17 +59,31 @@ def init(email: str, domain: str | None, session: str):
     install_cloudflared()
 
     console.print("[bold]Creating Cloudflare tunnel and access application...")
+    subdomain = domain or f"{os.getlogin()}.sshclaude.com"
     with Progress() as progress:
         t = progress.add_task("provision", total=4)
         progress.update(t, advance=1)
-        # Placeholder: create tunnel
-        progress.update(t, advance=1)
-        # Placeholder: create DNS record
-        progress.update(t, advance=1)
-        # Placeholder: create Access app/policy
-        progress.update(t, advance=1)
+        try:
+            resp = requests.post(
+                f"{API_URL}/provision",
+                json={"email": email, "subdomain": subdomain},
+                timeout=30,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+        except Exception as e:  # requests.exceptions.RequestException
+            console.print(f"[red]Provisioning failed: {e}")
+            return
+        progress.update(t, advance=3)
 
-    config = {"email": email, "domain": domain, "session": session}
+    config = {
+        "email": email,
+        "domain": subdomain,
+        "session": session,
+        "tunnel_id": data.get("tunnel_id"),
+        "dns_record_id": data.get("dns_record_id"),
+        "access_app_id": data.get("access_app_id"),
+    }
     write_config(config)
     console.print("[green]Initialization complete!")
 
@@ -80,8 +96,15 @@ def status():
         console.print("[red]sshclaude not initialized.")
         return
     console.print("[bold]Checking tunnel status...")
-    # Placeholder logic
-    console.print("Tunnel is running. Access app healthy.")
+    subdomain = config.get("domain")
+    try:
+        resp = requests.get(f"{API_URL}/provision/{subdomain}", timeout=15)
+        if resp.status_code == 200:
+            console.print("Tunnel is running. Access app healthy.")
+        else:
+            console.print("[red]Provision not found on server.")
+    except Exception as e:
+        console.print(f"[red]Failed to query status: {e}")
 
 
 @cli.command(name="rotate-key")
@@ -104,13 +127,21 @@ def uninstall():
         console.print("[red]sshclaude not initialized.")
         return
     console.print("[bold]Removing Cloudflare resources...")
+    subdomain = config.get("domain")
     with Progress() as progress:
         t = progress.add_task("cleanup", total=3)
         progress.update(t, advance=1)
-        # Placeholder: delete tunnel
-        progress.update(t, advance=1)
-        # Placeholder: delete DNS record
-        progress.update(t, advance=1)
+        try:
+            resp = requests.delete(
+                f"{API_URL}/provision/{subdomain}", timeout=30
+            )
+            if resp.status_code != 200:
+                console.print(f"[red]Delete failed: {resp.text}")
+                return
+        except Exception as e:
+            console.print(f"[red]Failed to delete resources: {e}")
+            return
+        progress.update(t, advance=2)
 
     CONFIG_FILE.unlink(missing_ok=True)
     console.print("[green]Uninstall complete.")


### PR DESCRIPTION
## Summary
- integrate CLI with provisioning API
- store Cloudflare resource IDs in config
- enable status and uninstall commands via API

## Testing
- `python -m compileall -q src/sshclaude`

------
https://chatgpt.com/codex/tasks/task_e_686a0cd2ac6c832daa50267cb3a9a58f