### PR TITLE
Add Cloudflare config vars and improve error messages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 # Example environment for sshclaude development
 CLOUDFLARE_TOKEN=
+CLOUDFLARE_ZONE_ID=
+CLOUDFLARE_ACCOUNT_ID=

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ sshclaude uninstall      # Remove tunnel + launchd service + DNS
 ## 🛠 Development
 
 1. `git clone` then run `./setup_env.sh` (or `make dev`) to install dependencies and pre‑commit hooks.
-2. `.env.example` → `.env` and add Cloudflare API token for staging zone.
+2. `.env.example` → `.env` and set `CLOUDFLARE_TOKEN`, `CLOUDFLARE_ZONE_ID`, and `CLOUDFLARE_ACCOUNT_ID` for the staging zone.
 3. Run local tunnel e2e with `make e2e` (uses ngrok for callback stubs).
 4. Launch the provisioning API with `sshclaude-api`.
 

--- a/src/sshclaude/cloudflare.py
+++ b/src/sshclaude/cloudflare.py
@@ -4,16 +4,24 @@ from __future__ import annotations
 
 import os
 from typing import Any
-
 import requests
+
+
+class MissingEnvError(RuntimeError):
+    """Raised when a required environment variable is missing."""
+
+
+def _require_env(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        raise MissingEnvError(f"Environment variable {name} is required but not set")
+    return value
 
 API_BASE = "https://api.cloudflare.com/client/v4"
 
 
 def _headers() -> dict[str, str]:
-    token = os.getenv("CLOUDFLARE_TOKEN")
-    if not token:
-        raise RuntimeError("CLOUDFLARE_TOKEN not set")
+    token = _require_env("CLOUDFLARE_TOKEN")
     return {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
 
 
@@ -36,9 +44,7 @@ def delete_tunnel(tunnel_id: str) -> None:
 
 
 def create_dns_record(subdomain: str, tunnel_id: str) -> dict[str, Any]:
-    zone_id = os.getenv("CLOUDFLARE_ZONE_ID")
-    if not zone_id:
-        raise RuntimeError("CLOUDFLARE_ZONE_ID not set")
+    zone_id = _require_env("CLOUDFLARE_ZONE_ID")
     resp = requests.post(
         f"{API_BASE}/zones/{zone_id}/dns_records",
         json={
@@ -54,9 +60,7 @@ def create_dns_record(subdomain: str, tunnel_id: str) -> dict[str, Any]:
 
 
 def delete_dns_record(record_id: str) -> None:
-    zone_id = os.getenv("CLOUDFLARE_ZONE_ID")
-    if not zone_id:
-        raise RuntimeError("CLOUDFLARE_ZONE_ID not set")
+    zone_id = _require_env("CLOUDFLARE_ZONE_ID")
     resp = requests.delete(
         f"{API_BASE}/zones/{zone_id}/dns_records/{record_id}",
         headers=_headers(),
@@ -66,9 +70,7 @@ def delete_dns_record(record_id: str) -> None:
 
 
 def create_access_app(email: str, subdomain: str) -> dict[str, Any]:
-    account_id = os.getenv("CLOUDFLARE_ACCOUNT_ID")
-    if not account_id:
-        raise RuntimeError("CLOUDFLARE_ACCOUNT_ID not set")
+    account_id = _require_env("CLOUDFLARE_ACCOUNT_ID")
     resp = requests.post(
         f"{API_BASE}/accounts/{account_id}/access/apps",
         json={
@@ -97,9 +99,7 @@ def create_access_app(email: str, subdomain: str) -> dict[str, Any]:
 
 
 def delete_access_app(app_id: str) -> None:
-    account_id = os.getenv("CLOUDFLARE_ACCOUNT_ID")
-    if not account_id:
-        raise RuntimeError("CLOUDFLARE_ACCOUNT_ID not set")
+    account_id = _require_env("CLOUDFLARE_ACCOUNT_ID")
     resp = requests.delete(
         f"{API_BASE}/accounts/{account_id}/access/apps/{app_id}",
         headers=_headers(),


### PR DESCRIPTION
## Summary
- add missing Cloudflare environment variables to `.env.example`
- document new variables in README
- improve error handling when required Cloudflare variables are absent

## Testing
- `python -m py_compile src/sshclaude/cloudflare.py`
- `python -m py_compile src/sshclaude/api.py src/sshclaude/cli.py`
- `pip install pre-commit black flake8 isort` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686a0cd0e80c832db10c643b0e0946b3