### PR TITLE
Implement persistence and AWS-ready features

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ Open **https\://\<user>.sshclaude.com** in Safari → SSO prompt → MFA / Face�
 | Component            | Language      | Responsibility                                    |
 | -------------------- | ------------- | ------------------------------------------------- |
 | **sshclaude‑cli**    | Python        | Local installer, daemon bootstrap, local UX.      |
-| **Provisioning API** | Python + FastAPI | Orbit on sshclaude.com; calls Cloudflare REST.    |
-| **State store**      | Postgres      | Maps user→sub‑domain→tunnel ID.                   |
+| **Provisioning API** | Python + FastAPI | Deployed on AWS Lambda via API Gateway; calls Cloudflare REST.    |
+| **State store**      | Postgres (RDS) | Maps user→sub-domain→tunnel ID and login history. |
 | **Web Console**      | React/Next.js | Shows login history, rotate keys, delete service. |
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,10 +14,13 @@ requests = "^2.32"
 tqdm = "^4.66"
 fastapi = "^0.110"
 uvicorn = "^0.27"
+SQLAlchemy = "^2.0"
+mangum = "^0.17"
 
 [tool.poetry.scripts]
 sshclaude = "sshclaude.cli:cli"
 sshclaude-api = "sshclaude.api:main"
+sshclaude-api-lambda = "sshclaude.api:lambda_handler"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/src/sshclaude/cloudflare.py
+++ b/src/sshclaude/cloudflare.py
@@ -106,3 +106,13 @@ def delete_access_app(app_id: str) -> None:
         timeout=30,
     )
     resp.raise_for_status()
+
+
+def rotate_host_key(tunnel_id: str) -> None:
+    """Trigger host key rotation via Cloudflare API."""
+    resp = requests.post(
+        f"{API_BASE}/tunnels/{tunnel_id}/hostkey/rotate",
+        headers=_headers(),
+        timeout=30,
+    )
+    resp.raise_for_status()

--- a/src/sshclaude/db.py
+++ b/src/sshclaude/db.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from typing import Generator
+
+from sqlalchemy import Column, Integer, String, create_engine, DateTime
+from sqlalchemy.orm import declarative_base, sessionmaker
+from datetime import datetime
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./sshclaude.db")
+engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {})
+SessionLocal = sessionmaker(bind=engine)
+
+Base = declarative_base()
+
+
+class Provision(Base):
+    __tablename__ = "provisions"
+
+    id = Column(Integer, primary_key=True, index=True)
+    email = Column(String, nullable=False)
+    subdomain = Column(String, unique=True, nullable=False)
+    tunnel_id = Column(String, nullable=False)
+    dns_record_id = Column(String, nullable=False)
+    access_app_id = Column(String, nullable=False)
+
+
+class LoginEvent(Base):
+    __tablename__ = "login_events"
+
+    id = Column(Integer, primary_key=True, index=True)
+    subdomain = Column(String, index=True, nullable=False)
+    user = Column(String, nullable=False)
+    ip = Column(String, nullable=False)
+    timestamp = Column(DateTime, default=datetime.utcnow)
+
+
+def init_db() -> None:
+    Base.metadata.create_all(bind=engine)
+
+
+@contextmanager
+def get_session() -> Generator:
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()


### PR DESCRIPTION
## Summary
- add SQLAlchemy models and database helper
- secure the API with token auth and Lambda handler
- store provisioning data and login events in Postgres
- implement host key rotation API call
- manage cloudflared with launchd via CLI
- add basic tests for API
- update README components table

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install fastapi sqlalchemy mangum` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686a0e9dd8a4832da6ee1f4de1a5cb17