### PR TITLE
Add provision lookup API route

### DIFF
--- a/src/sshclaude/api.py
+++ b/src/sshclaude/api.py
@@ -60,6 +60,20 @@ def provision(req: ProvisionRequest) -> ProvisionResponse:
     return ProvisionResponse(**data)
 
 
+@app.get("/provision/{subdomain}", response_model=ProvisionResponse, dependencies=[Depends(verify_token)])
+def get_provision(subdomain: str) -> ProvisionResponse:
+    """Return provision details for a subdomain."""
+    with get_session() as db:
+        provision = db.query(Provision).filter_by(subdomain=subdomain).first()
+        if not provision:
+            raise HTTPException(status_code=404, detail="unknown subdomain")
+        return ProvisionResponse(
+            tunnel_id=provision.tunnel_id,
+            dns_record_id=provision.dns_record_id,
+            access_app_id=provision.access_app_id,
+        )
+
+
 @app.delete("/provision/{subdomain}", dependencies=[Depends(verify_token)])
 def delete_provision(subdomain: str) -> dict[str, str]:
     with get_session() as db:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -33,15 +33,26 @@ def test_provision_cycle(monkeypatch):
     monkeypatch.setattr("sshclaude.cloudflare.create_tunnel", fake_create_tunnel)
     monkeypatch.setattr("sshclaude.cloudflare.create_dns_record", fake_create_dns_record)
     monkeypatch.setattr("sshclaude.cloudflare.create_access_app", fake_create_access_app)
+    monkeypatch.setattr("sshclaude.cloudflare.rotate_host_key", lambda tid: None)
+    monkeypatch.setattr("sshclaude.cloudflare.delete_access_app", lambda app_id: None)
+    monkeypatch.setattr("sshclaude.cloudflare.delete_dns_record", lambda rec_id: None)
+    monkeypatch.setattr("sshclaude.cloudflare.delete_tunnel", lambda tid: None)
 
     resp = client.post("/provision", json={"email": "a@b.com", "subdomain": "test"})
     assert resp.status_code == 200
     data = resp.json()
     assert data["tunnel_id"] == "tid"
 
+    resp = client.get("/provision/test")
+    assert resp.status_code == 200
+    assert resp.json() == {"tunnel_id": "tid", "dns_record_id": "dns", "access_app_id": "app"}
+
     resp = client.post("/rotate-key/test")
     assert resp.status_code == 200
 
     resp = client.delete("/provision/test")
     assert resp.status_code == 200
+
+    resp = client.get("/provision/test")
+    assert resp.status_code == 404
 


### PR DESCRIPTION
## Summary
- implement `/provision/{subdomain}` endpoint
- test retrieval of provision details

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686c389b30e4832d9cf68cdee13636e2