### PR TITLE
Implement ttyd automation features

### DIFF
--- a/src/sshclaude/cloudflare.py
+++ b/src/sshclaude/cloudflare.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import secrets
 from typing import Any
 import requests
 
@@ -116,3 +117,9 @@ def rotate_host_key(tunnel_id: str) -> None:
         timeout=30,
     )
     resp.raise_for_status()
+
+
+def generate_tunnel_token(tunnel_id: str) -> str:
+    """Return a new connector token for the tunnel."""
+    # Real implementation would call Cloudflare API. Here we stub it.
+    return secrets.token_urlsafe(32)

--- a/src/sshclaude/db.py
+++ b/src/sshclaude/db.py
@@ -28,6 +28,7 @@ class Provision(Base):
     email = Column(String, nullable=False)
     subdomain = Column(String, unique=True, nullable=False)
     tunnel_id = Column(String, nullable=False)
+    tunnel_token = Column(String, nullable=False)
     dns_record_id = Column(String, nullable=False)
     access_app_id = Column(String, nullable=False)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -48,11 +48,13 @@ def test_provision_cycle(monkeypatch):
     assert resp.status_code == 200
     data = resp.json()
     assert data["tunnel_id"] == "tid"
+    assert "tunnel_token" in data
 
     resp = client.get("/provision/test")
     assert resp.status_code == 200
     assert resp.json() == {
         "tunnel_id": "tid",
+        "tunnel_token": data["tunnel_token"],
         "dns_record_id": "dns",
         "access_app_id": "app",
     }


### PR DESCRIPTION
## Summary
- handle tunnel token and ttyd automation per README
- generate dummy tunnel token server-side
- update CLI to install ttyd, create launcher, and configure cloudflared
- store token in Provision DB
- expose token in API responses
- adjust tests for new field

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -q` *(fails: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686dc03eaa3c832d8fd2e97e199bfae2