### PR TITLE
Support init reusing existing config

### DIFF
--- a/src/sshclaude/cli.py
+++ b/src/sshclaude/cli.py
@@ -116,7 +116,16 @@ def init(github: str, domain: str | None, session: str):
 
     config = read_config()
     if config:
-        console.print("[yellow]sshclaude already initialized.")
+        console.print("[yellow]Existing configuration found - reusing token.")
+        subdomain = config.get("domain")
+        token = config.get("tunnel_token")
+        if not subdomain or not token:
+            console.print("[red]Configuration incomplete. Remove ~/.sshclaude and re-run init.")
+            return
+        write_tunnel_files(subdomain, token)
+        write_launcher()
+        write_plist(token)
+        console.print(f"[green]sshclaude started at https://{subdomain}")
         return
 
     install_cloudflared()


### PR DESCRIPTION
## Summary
- reuse existing token/config when running `sshclaude init` a second time

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68712a72d5ec832da4c41a1209edda57