### PR TITLE
Secure delete with tunnel token

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ sequenceDiagram
    * `sshclaude status` – check the tunnel and Access app health
    * `sshclaude refresh-token` – rotate the Cloudflare tunnel token
    * `sshclaude stop` – stop the running tunnel and ttyd session without deleting anything 
-   * `sshclaude uninstall` – remove all Cloudflare resources and local files
+  * `sshclaude uninstall` – remove all Cloudflare resources and local files (requires your tunnel token)
 
 When `sshclaude init` runs it will:
 

--- a/src/sshclaude/cli.py
+++ b/src/sshclaude/cli.py
@@ -341,7 +341,11 @@ def uninstall():
         t = progress.add_task("cleanup", total=3)
         progress.update(t, advance=1)
         try:
-            resp = requests.delete(f"{API_URL}/provision/{subdomain}", timeout=30)
+            resp = requests.delete(
+                f"{API_URL}/provision/{subdomain}",
+                json={"tunnel_token": config.get("tunnel_token")},
+                timeout=30,
+            )
             if resp.status_code != 200:
                 console.print(f"[red]Delete failed: {resp.text}")
                 return

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -62,7 +62,7 @@ def test_provision_cycle(monkeypatch):
     resp = client.post("/rotate-key/test")
     assert resp.status_code == 200
 
-    resp = client.delete("/provision/test")
+    resp = client.delete("/provision/test", json={"tunnel_token": data["tunnel_token"]})
     assert resp.status_code == 200
 
     resp = client.get("/provision/test")


### PR DESCRIPTION
## Summary
- require tunnel token in delete API
- send token from CLI uninstall command
- document uninstall token requirement
- update tests for token validation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_687155cf8e58832db2c0d8249148cc4a